### PR TITLE
Fix voltage limit bug

### DIFF
--- a/examples/M3/CANProfile.h
+++ b/examples/M3/CANProfile.h
@@ -10,8 +10,10 @@
 // phase resistance of the motor = internal resistance / 2
 // 17.0Ω / 2 = 8.5Ω
 #define PHASE_RESISTANCE 8.5
-// Seting a voltage limit too high can cause the motor to overheat and damage the driver.
-// reference: https://docs.simplefoc.com/voltage_torque_mode#configuration-and-torque-limits
+// Seting a voltage limit too high can cause the motor to overheat and damage
+// the driver.
+// Reference:
+// https://docs.simplefoc.com/voltage_torque_mode#configuration-and-torque-limits
 #define VOLTAGE_LIMIT 8.0
 
 typedef enum { SET_TARGET = 0, REQUEST_TARGET, NONE } MESSAGE_STATUS;

--- a/src/CANProfile.h
+++ b/src/CANProfile.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define MOTOR_ID 0x00 // change this to your motor ID
 #define ANGLE_COMMAND_OFFSET 0x20
 #define POS_COMMAND_OFFSET 0x30

--- a/src/MotorConfig.h
+++ b/src/MotorConfig.h
@@ -1,0 +1,4 @@
+#pragma once
+
+constexpr float VOLTAGE_POWER_SUPPLY = 24.0f;
+constexpr float DEFAULT_VOLTAGE_LIMIT = 6.0f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,10 +45,11 @@ void applyPIDConfig(const float *config, uint8_t count) {
     motor.P_angle.P = config[3];
   }
   if (count >= 5) {
-    motor.voltage_limit = config[4];
+    float voltageLimit = constrain(config[4], 0.0f, driver.voltage_power_supply);
+    motor.updateVoltageLimit(voltageLimit);
   }
   if (count >= 6) {
-    motor.velocity_limit = config[5];
+    motor.updateVelocityLimit(config[5]);
   }
   if (count >= 7) {
     motor.LPF_velocity.Tf = config[6];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <math.h>
 #include "CANProfile.h"
+#include "MotorConfig.h"
 #include "STM32CAN.h"
 #include "SPI.h"
 #include "SimpleFOC.h"
@@ -45,7 +46,8 @@ void applyPIDConfig(const float *config, uint8_t count) {
     motor.P_angle.P = config[3];
   }
   if (count >= 5) {
-    float voltageLimit = constrain(config[4], 0.0f, driver.voltage_power_supply);
+    float voltageLimit =
+        constrain(config[4], 0.0f, driver.voltage_power_supply);
     motor.updateVoltageLimit(voltageLimit);
   }
   if (count >= 6) {
@@ -328,13 +330,14 @@ void configureFOC() {
   sensor1.init();
   motor.linkSensor(&sensor1);
 
-  driver.voltage_power_supply = 24;
+  driver.voltage_power_supply = VOLTAGE_POWER_SUPPLY;
   driver.init();
   motor.linkDriver(&driver);
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
   motor.controller = MotionControlType::angle;
 
-  float defaultPIDConfig[7] = {0.2f, 20.0f, 0.001f, 20.0f, 6.0f, 10.0f, 0.01f};
+  float defaultPIDConfig[7] = {
+      0.2f, 20.0f, 0.001f, 20.0f, DEFAULT_VOLTAGE_LIMIT, 10.0f, 0.01f};
   applyPIDConfig(defaultPIDConfig, 7);
 
   // initialize motor


### PR DESCRIPTION
## Summary

Fix runtime voltage and velocity limit updates received through CAN in closed-loop angle control.

## Changes

- Use `motor.updateVoltageLimit()` so SimpleFOC updates the internal PID limits after initialization.
- Constrain CAN-provided voltage limits to the configured supply range.
- Use `motor.updateVelocityLimit()` to update the associated angle-controller limit.
- Move the fixed 24 V supply and default 6 V motor limit into `MotorConfig.h`.
- Add header protection with `#pragma once`.
- Improve formatting of the voltage-limit safety warning in the M3 example.

## Motivation

Previously, assigning directly to `motor.voltage_limit` after `initFOC()` did not update the velocity PID’s internal output limit. As a result, lowering the voltage limit below the initial 6 V worked, but raising it above 6 V had no noticeable effect in closed-loop angle mode.

Using SimpleFOC’s runtime update APIs keeps the motor configuration and internal controller limits synchronized.

The supply voltage remains fixed at 24 V because the production controller is designed for a 24 V power supply. Dynamic voltage-limit commands cannot exceed this configured value.